### PR TITLE
Add basic JSON API with rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # AI Proxy Web
 
 Simple PHP web application for forwarding AI API requests.
+Provides a JSON API with basic rate limiting and weighted key rotation.
 
 ## Setup
 
@@ -12,7 +13,8 @@ Simple PHP web application for forwarding AI API requests.
 
 - Manage third-party API keys.
 - Generate site-specific `One_Key` identifiers.
-- Stateless chat API at `/public/chat.php`.
+- Stateless chat API at `/public/api_chat.php` returning JSON with `status`, `data` and `message` fields.
+- Basic OpenAPI description provided in `openapi.yaml`.
 - Basic function test panel.
 
 This is a minimal demonstration and uses MD5 for password storage as requested.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,37 @@
+openapi: 3.0.0
+info:
+  title: AI Proxy API
+  version: 1.0.0
+paths:
+  /api_chat.php:
+    post:
+      summary: Chat with AI
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: object
+                properties:
+                  One_Key:
+                    type: string
+                  role:
+                    type: string
+                  content:
+                    type: string
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                  data:
+                    type: object
+                  message:
+                    type: string

--- a/public/api_chat.php
+++ b/public/api_chat.php
@@ -1,0 +1,31 @@
+<?php
+require __DIR__.'/lib.php';
+$pdo = get_pdo();
+$input = json_decode(file_get_contents('php://input'), true);
+if(!$input || !isset($input[0]['One_Key'])){
+    http_response_code(400);
+    api_response(400, [], 'Invalid request');
+}
+$key = $input[0]['One_Key'];
+$stmt = $pdo->prepare('SELECT * FROM one_keys WHERE one_key=?');
+$stmt->execute([$key]);
+$one = $stmt->fetch(PDO::FETCH_ASSOC);
+if(!$one){
+    http_response_code(403);
+    api_response(403, [], 'Invalid Key');
+}
+rate_limit_check($one);
+$apiKey = select_api_key();
+if(!$apiKey){
+    api_response(500, [], 'No API Key');
+}
+$messages=[];
+foreach($input as $msg){
+    $messages[]=['role'=>$msg['role'],'content'=>$msg['content']];
+}
+// placeholder external API call
+$response=['role'=>'assistant','content'=>'Simulated response'];
+$tokenCount = strlen(json_encode($messages));
+$pdo->prepare('UPDATE one_keys SET tokens_used = tokens_used + ? WHERE id=?')->execute([$tokenCount,$one['id']]);
+api_response(200, $response, 'ok');
+?>

--- a/public/chat.php
+++ b/public/chat.php
@@ -1,18 +1,18 @@
 <?php
-$config = require __DIR__ . '/../config.php';
-$pdo = new PDO("mysql:host={$config['db_host']};dbname={$config['db_name']};charset=utf8mb4", $config['db_user'], $config['db_pass']);
+require __DIR__.'/lib.php';
+$pdo = get_pdo();
 $input = json_decode(file_get_contents('php://input'), true);
-if (!$input || !isset($input[0]['One_Key'])) { http_response_code(400); echo 'Invalid'; exit; }
+if (!$input || !isset($input[0]['One_Key'])) { http_response_code(400); api_response(400,[], 'Invalid'); }
 $key = $input[0]['One_Key'];
 $stmt = $pdo->prepare('SELECT * FROM one_keys WHERE one_key=?');
 $stmt->execute([$key]);
 $one = $stmt->fetch(PDO::FETCH_ASSOC);
-if (!$one) { http_response_code(403); echo 'Invalid Key'; exit; }
+if (!$one) { http_response_code(403); api_response(403,[], 'Invalid Key'); }
+rate_limit_check($one);
 
 // Here we should forward to third-party API using stored api_keys
-$apiKeyRow = $pdo->query('SELECT api_key FROM api_keys WHERE active=1 LIMIT 1')->fetch(PDO::FETCH_ASSOC);
-if(!$apiKeyRow){http_response_code(500); echo 'No API Key'; exit;}
-$apiKey = $apiKeyRow['api_key'];
+$apiKey = select_api_key();
+if(!$apiKey){ api_response(500,[], 'No API Key'); }
 
 // Build conversation for forwarding
 $messages = [];
@@ -27,5 +27,4 @@ $response = ['role'=>'assistant','content'=>'Simulated response'];
 $tokenCount = strlen(json_encode($messages));
 $pdo->prepare('UPDATE one_keys SET tokens_used = tokens_used + ? WHERE id=?')->execute([$tokenCount,$one['id']]);
 
-header('Content-Type: application/json');
-echo json_encode($response);
+api_response(200, $response, 'ok');

--- a/public/lib.php
+++ b/public/lib.php
@@ -1,0 +1,52 @@
+<?php
+function get_pdo(){
+    static $pdo=null;
+    if($pdo===null){
+        $config = require __DIR__ . '/../config.php';
+        $pdo = new PDO("mysql:host={$config['db_host']};dbname={$config['db_name']};charset=utf8mb4", $config['db_user'], $config['db_pass']);
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    }
+    return $pdo;
+}
+
+function api_response($status,$data=[], $message=''){
+    header('Content-Type: application/json; charset=utf-8');
+    echo json_encode(['status'=>$status,'data'=>$data,'message'=>$message], JSON_UNESCAPED_UNICODE);
+    exit;
+}
+
+function select_api_key(){
+    $pdo = get_pdo();
+    $rows = $pdo->query('SELECT api_key,weight FROM api_keys WHERE active=1')->fetchAll(PDO::FETCH_ASSOC);
+    if(!$rows){
+        return null;
+    }
+    $pool=[];
+    foreach($rows as $r){
+        for($i=0;$i<$r['weight'];$i++){
+            $pool[]=$r['api_key'];
+        }
+    }
+    return $pool[array_rand($pool)];
+}
+
+function rate_limit_check($one){
+    $pdo = get_pdo();
+    $now = time();
+    $allowance = $one['allowance'];
+    $limit = $one['qps_limit'];
+    $allowance += ($now - $one['last_check']) * $limit;
+    if($allowance > $limit) $allowance = $limit;
+    if($allowance < 1){
+        $wait = ceil((1 - $allowance) / $limit);
+        $stmt = $pdo->prepare('UPDATE one_keys SET allowance=?, last_check=? WHERE id=?');
+        $stmt->execute([$allowance, $now, $one['id']]);
+        header('Retry-After: '.$wait);
+        http_response_code(429);
+        api_response(429, [], "Rate limit exceeded, retry after {$wait}s");
+    }
+    $allowance -= 1;
+    $stmt = $pdo->prepare('UPDATE one_keys SET allowance=?, last_check=? WHERE id=?');
+    $stmt->execute([$allowance, $now, $one['id']]);
+}
+?>

--- a/public/setup.php
+++ b/public/setup.php
@@ -19,8 +19,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $pdo->exec("CREATE DATABASE IF NOT EXISTS `$db_name` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
         $pdo->exec("USE `$db_name`");
         $pdo->exec("CREATE TABLE users(id INT AUTO_INCREMENT PRIMARY KEY, username VARCHAR(50) UNIQUE, password VARCHAR(32))");
-        $pdo->exec("CREATE TABLE api_keys(id INT AUTO_INCREMENT PRIMARY KEY, api_key VARCHAR(255), remark VARCHAR(255), active TINYINT(1) DEFAULT 1, flag INT)");
-        $pdo->exec("CREATE TABLE one_keys(id INT AUTO_INCREMENT PRIMARY KEY, one_key CHAR(24) UNIQUE, remark VARCHAR(255), tokens_used INT DEFAULT 0)");
+        $pdo->exec("CREATE TABLE api_keys(id INT AUTO_INCREMENT PRIMARY KEY, api_key VARCHAR(255), remark VARCHAR(255), active TINYINT(1) DEFAULT 1, flag INT, weight INT DEFAULT 1)");
+        $pdo->exec("CREATE TABLE one_keys(id INT AUTO_INCREMENT PRIMARY KEY, one_key CHAR(24) UNIQUE, remark VARCHAR(255), tokens_used INT DEFAULT 0, qps_limit INT DEFAULT 60, allowance FLOAT DEFAULT 60, last_check INT DEFAULT 0)");
         $stmt = $pdo->prepare('INSERT INTO users(username,password) VALUES(?,?)');
         $stmt->execute([$admin,$admin_pass]);
         $config = ['db_host'=>$db_host,'db_user'=>$db_user,'db_pass'=>$db_pass,'db_name'=>$db_name];


### PR DESCRIPTION
## Summary
- add token bucket and weighted key logic in new `lib.php`
- expose new `/public/api_chat.php` endpoint using standardized JSON format
- update old chat endpoint to use helper functions and rate limiting
- extend setup script for new DB columns
- document features and provide an OpenAPI description

## Testing
- `php -l public/lib.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68418a0eee748323ab07dd52172dc964