### PR TITLE
Enhance UI with responsive layout and stats dashboard

### DIFF
--- a/public/api_chat.php
+++ b/public/api_chat.php
@@ -3,6 +3,7 @@ require __DIR__.'/lib.php';
 $pdo = get_pdo();
 $input = json_decode(file_get_contents('php://input'), true);
 if(!$input || !isset($input[0]['One_Key'])){
+    log_api_call(false);
     http_response_code(400);
     api_response(400, [], 'Invalid request');
 }
@@ -11,12 +12,14 @@ $stmt = $pdo->prepare('SELECT * FROM one_keys WHERE one_key=?');
 $stmt->execute([$key]);
 $one = $stmt->fetch(PDO::FETCH_ASSOC);
 if(!$one){
+    log_api_call(false);
     http_response_code(403);
     api_response(403, [], 'Invalid Key');
 }
 rate_limit_check($one);
 $apiKey = select_api_key();
 if(!$apiKey){
+    log_api_call(false);
     api_response(500, [], 'No API Key');
 }
 $messages=[];
@@ -27,5 +30,6 @@ foreach($input as $msg){
 $response=['role'=>'assistant','content'=>'Simulated response'];
 $tokenCount = strlen(json_encode($messages));
 $pdo->prepare('UPDATE one_keys SET tokens_used = tokens_used + ? WHERE id=?')->execute([$tokenCount,$one['id']]);
+log_api_call(true,$tokenCount);
 api_response(200, $response, 'ok');
 ?>

--- a/public/api_keys.php
+++ b/public/api_keys.php
@@ -15,9 +15,29 @@ if (isset($_GET['delete'])) {
 $keys = $pdo->query('SELECT * FROM api_keys')->fetchAll(PDO::FETCH_ASSOC);
 ?>
 <!DOCTYPE html>
-<html><head><meta charset="utf-8"><title>API Keys</title></head><body>
+<html>
+<head>
+<meta charset="utf-8">
+<title>API Keys</title>
+<link rel="stylesheet" href="style.css">
+<script src="script.js" defer></script>
+</head>
+<body>
+<div class="nav">
+    <div class="nav-links">
+        <a href="dashboard.php">Dashboard</a>
+        <a href="api_keys.php">API Keys</a>
+        <a href="one_keys.php">One Keys</a>
+        <a href="test.php">Function Test</a>
+        <a href="stats.php">Stats</a>
+        <a href="logout.php">Logout</a>
+    </div>
+    <button class="nav-toggle" onclick="toggleNav()">☰</button>
+    <button id="theme-toggle" class="nav-toggle" onclick="toggleTheme()">🌗</button>
+</div>
+<div class="content">
 <h2>API Keys</h2>
-<form method="post">
+<form method="post" onsubmit="return validateForm()">
     <input name="api_key" placeholder="API Key" required>
     <input name="remark" placeholder="Remark">
     <input name="flag" placeholder="Platform Flag" value="1">
@@ -37,5 +57,8 @@ $keys = $pdo->query('SELECT * FROM api_keys')->fetchAll(PDO::FETCH_ASSOC);
 </tr>
 <?php endforeach; ?>
 </table>
-<p><a href="dashboard.php">Back</a></p>
-</body></html>
+</div>
+<div id="loading" class="loading-overlay"><div>Loading...</div></div>
+<div class="toast-container"></div>
+</body>
+</html>

--- a/public/chat.php
+++ b/public/chat.php
@@ -2,17 +2,17 @@
 require __DIR__.'/lib.php';
 $pdo = get_pdo();
 $input = json_decode(file_get_contents('php://input'), true);
-if (!$input || !isset($input[0]['One_Key'])) { http_response_code(400); api_response(400,[], 'Invalid'); }
+if (!$input || !isset($input[0]['One_Key'])) { log_api_call(false); http_response_code(400); api_response(400,[], 'Invalid'); }
 $key = $input[0]['One_Key'];
 $stmt = $pdo->prepare('SELECT * FROM one_keys WHERE one_key=?');
 $stmt->execute([$key]);
 $one = $stmt->fetch(PDO::FETCH_ASSOC);
-if (!$one) { http_response_code(403); api_response(403,[], 'Invalid Key'); }
+if (!$one) { log_api_call(false); http_response_code(403); api_response(403,[], 'Invalid Key'); }
 rate_limit_check($one);
 
 // Here we should forward to third-party API using stored api_keys
 $apiKey = select_api_key();
-if(!$apiKey){ api_response(500,[], 'No API Key'); }
+if(!$apiKey){ log_api_call(false); api_response(500,[], 'No API Key'); }
 
 // Build conversation for forwarding
 $messages = [];
@@ -26,5 +26,6 @@ $response = ['role'=>'assistant','content'=>'Simulated response'];
 // update tokens_used (simple count of characters as tokens)
 $tokenCount = strlen(json_encode($messages));
 $pdo->prepare('UPDATE one_keys SET tokens_used = tokens_used + ? WHERE id=?')->execute([$tokenCount,$one['id']]);
+log_api_call(true,$tokenCount);
 
 api_response(200, $response, 'ok');

--- a/public/dashboard.php
+++ b/public/dashboard.php
@@ -12,24 +12,32 @@ $pdo = new PDO("mysql:host={$config['db_host']};dbname={$config['db_name']};char
 <head>
 <meta charset="utf-8">
 <title>Dashboard</title>
+<link rel="stylesheet" href="style.css">
+<script src="script.js" defer></script>
 <style>
-body{font-family:Arial;margin:0;display:flex;height:100vh;}
-.sidebar{width:200px;background:#333;color:#fff;padding:20px;}
-.content{flex:1;padding:20px;}
-a{color:#fff;display:block;margin-bottom:10px;text-decoration:none;}
+.sidebar a{color:#fff;display:block;margin-bottom:10px;text-decoration:none;}
+.layout{display:flex;height:100vh;}
+@media(max-width:600px){.sidebar{width:100%;}}
 </style>
 </head>
 <body>
-<div class="sidebar">
-    <h3>Menu</h3>
-    <a href="api_keys.php">API Keys</a>
-    <a href="one_keys.php">One Keys</a>
-    <a href="test.php">Function Test</a>
-    <a href="logout.php">Logout</a>
+<div class="nav">
+    <div class="nav-links">
+        <a href="dashboard.php">Dashboard</a>
+        <a href="api_keys.php">API Keys</a>
+        <a href="one_keys.php">One Keys</a>
+        <a href="test.php">Function Test</a>
+        <a href="stats.php">Stats</a>
+        <a href="logout.php">Logout</a>
+    </div>
+    <button class="nav-toggle" onclick="toggleNav()">☰</button>
+    <button id="theme-toggle" class="nav-toggle" onclick="toggleTheme()">🌗</button>
 </div>
 <div class="content">
     <h2>Welcome</h2>
     <p>Select a menu item.</p>
 </div>
+<div id="loading" class="loading-overlay"><div>Loading...</div></div>
+<div class="toast-container"></div>
 </body>
 </html>

--- a/public/index.php
+++ b/public/index.php
@@ -36,15 +36,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <head>
     <meta charset="utf-8">
     <title>Login</title>
-    <style>
-        body{font-family: Arial; display:flex;justify-content:center;align-items:center;height:100vh;background:#f5f5f5;}
-        .login{background:#fff;padding:20px;border-radius:4px;box-shadow:0 2px 4px rgba(0,0,0,.1);}        
-        input{display:block;margin-bottom:10px;width:100%;padding:8px;}
-    </style>
+    <link rel="stylesheet" href="style.css">
+    <script src="script.js" defer></script>
+    <style>.login{background:#fff;padding:20px;border-radius:4px;box-shadow:0 2px 4px rgba(0,0,0,.1);}</style>
 </head>
 <body>
 <div class="login">
-    <form method="post">
+    <form method="post" onsubmit="return validateForm()">
         <h2>Login</h2>
         <?php if($error) echo "<p style='color:red'>$error</p>"; ?>
         <input name="username" placeholder="Username" required>
@@ -52,5 +50,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <button type="submit">Login</button>
     </form>
 </div>
+<div id="loading" class="loading-overlay"><div>Loading...</div></div>
+<div class="toast-container"></div>
 </body>
 </html>

--- a/public/lib.php
+++ b/public/lib.php
@@ -49,4 +49,10 @@ function rate_limit_check($one){
     $stmt = $pdo->prepare('UPDATE one_keys SET allowance=?, last_check=? WHERE id=?');
     $stmt->execute([$allowance, $now, $one['id']]);
 }
+
+function log_api_call($success,$tokens=0){
+    $pdo=get_pdo();
+    $stmt=$pdo->prepare('INSERT INTO api_logs(success,tokens) VALUES(?,?)');
+    $stmt->execute([$success?1:0,$tokens]);
+}
 ?>

--- a/public/one_keys.php
+++ b/public/one_keys.php
@@ -18,9 +18,29 @@ if (isset($_GET['delete'])) {
 $keys = $pdo->query('SELECT * FROM one_keys')->fetchAll(PDO::FETCH_ASSOC);
 ?>
 <!DOCTYPE html>
-<html><head><meta charset="utf-8"><title>One Keys</title></head><body>
+<html>
+<head>
+<meta charset="utf-8">
+<title>One Keys</title>
+<link rel="stylesheet" href="style.css">
+<script src="script.js" defer></script>
+</head>
+<body>
+<div class="nav">
+    <div class="nav-links">
+        <a href="dashboard.php">Dashboard</a>
+        <a href="api_keys.php">API Keys</a>
+        <a href="one_keys.php">One Keys</a>
+        <a href="test.php">Function Test</a>
+        <a href="stats.php">Stats</a>
+        <a href="logout.php">Logout</a>
+    </div>
+    <button class="nav-toggle" onclick="toggleNav()">☰</button>
+    <button id="theme-toggle" class="nav-toggle" onclick="toggleTheme()">🌗</button>
+</div>
+<div class="content">
 <h2>One Keys</h2>
-<form method="post">
+<form method="post" onsubmit="return validateForm()">
     <input name="remark" placeholder="Remark">
     <button name="add" type="submit">Generate</button>
 </form>
@@ -36,5 +56,8 @@ $keys = $pdo->query('SELECT * FROM one_keys')->fetchAll(PDO::FETCH_ASSOC);
 </tr>
 <?php endforeach; ?>
 </table>
-<p><a href="dashboard.php">Back</a></p>
-</body></html>
+</div>
+<div id="loading" class="loading-overlay"><div>Loading...</div></div>
+<div class="toast-container"></div>
+</body>
+</html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,10 @@
+function setTheme(t){document.documentElement.setAttribute('data-theme',t);localStorage.setItem('theme',t);} 
+function toggleTheme(){const cur=document.documentElement.getAttribute('data-theme')==='dark'?'light':'dark';setTheme(cur);} 
+function initTheme(){setTheme(localStorage.getItem('theme')||'light');}
+function showLoading(){const l=document.getElementById('loading');if(l)l.style.display='flex';}
+function hideLoading(){const l=document.getElementById('loading');if(l)l.style.display='none';}
+function showToast(msg,type){const c=document.querySelector('.toast-container');if(!c)return;const t=document.createElement('div');t.className='toast '+type;t.textContent=msg;c.appendChild(t);setTimeout(()=>t.remove(),3000);} 
+function updateProgress(p){const bar=document.querySelector('.progress-bar div');if(bar)bar.style.width=p+'%';}
+function toggleNav(){const n=document.querySelector('.nav-links');if(n)n.classList.toggle('show');}
+function validateForm(){const req=document.querySelectorAll('input[required]');for(const r of req){if(!r.value.trim()){showToast('Please fill '+(r.name||r.placeholder),'error');r.focus();return false;}}return true;}
+document.addEventListener('DOMContentLoaded',initTheme);

--- a/public/setup.php
+++ b/public/setup.php
@@ -21,6 +21,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $pdo->exec("CREATE TABLE users(id INT AUTO_INCREMENT PRIMARY KEY, username VARCHAR(50) UNIQUE, password VARCHAR(32))");
         $pdo->exec("CREATE TABLE api_keys(id INT AUTO_INCREMENT PRIMARY KEY, api_key VARCHAR(255), remark VARCHAR(255), active TINYINT(1) DEFAULT 1, flag INT, weight INT DEFAULT 1)");
         $pdo->exec("CREATE TABLE one_keys(id INT AUTO_INCREMENT PRIMARY KEY, one_key CHAR(24) UNIQUE, remark VARCHAR(255), tokens_used INT DEFAULT 0, qps_limit INT DEFAULT 60, allowance FLOAT DEFAULT 60, last_check INT DEFAULT 0)");
+        $pdo->exec("CREATE TABLE api_logs(id INT AUTO_INCREMENT PRIMARY KEY, success TINYINT(1), tokens INT DEFAULT 0, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)");
         $stmt = $pdo->prepare('INSERT INTO users(username,password) VALUES(?,?)');
         $stmt->execute([$admin,$admin_pass]);
         $config = ['db_host'=>$db_host,'db_user'=>$db_user,'db_pass'=>$db_pass,'db_name'=>$db_name];

--- a/public/stats.php
+++ b/public/stats.php
@@ -1,0 +1,63 @@
+<?php
+session_start();
+if(!isset($_SESSION['user_id'])){header('Location: index.php');exit;}
+?>
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Stats</title>
+<link rel="stylesheet" href="style.css">
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script src="script.js" defer></script>
+</head>
+<body>
+<div class="nav">
+    <div class="nav-links">
+        <a href="dashboard.php">Dashboard</a>
+        <a href="api_keys.php">API Keys</a>
+        <a href="one_keys.php">One Keys</a>
+        <a href="test.php">Function Test</a>
+        <a href="stats.php">Stats</a>
+        <a href="logout.php">Logout</a>
+    </div>
+    <button class="nav-toggle" onclick="toggleNav()">☰</button>
+    <button id="theme-toggle" class="nav-toggle" onclick="toggleTheme()">🌗</button>
+</div>
+<div class="content">
+    <h2>Usage Statistics</h2>
+    <canvas id="tokenChart"></canvas>
+    <canvas id="successGauge" width="200" height="200"></canvas>
+    <div class="progress-bar"><div></div></div>
+    <button onclick="exportCharts()">Export</button>
+</div>
+<div id="loading" class="loading-overlay"><div>Loading...</div></div>
+<div class="toast-container"></div>
+<script>
+function loadStats(){
+    showLoading();
+    fetch('stats_data.php').then(r=>r.json()).then(d=>{
+        hideLoading();
+        updateProgress(100);
+        new Chart(document.getElementById('tokenChart').getContext('2d'),{
+            type:'line',
+            data:{labels:d.tokens.labels,datasets:[{label:'Tokens',data:d.tokens.data,fill:false,borderColor:'#09f'}]}
+        });
+        new Chart(document.getElementById('successGauge').getContext('2d'),{
+            type:'doughnut',
+            data:{labels:['Success','Fail'],datasets:[{data:[d.success,100-d.success],backgroundColor:['#4caf50','#f44336']}]},
+            options:{circumference:180,rotation:270,cutout:'70%'}
+        });
+    }).catch(()=>{hideLoading();showToast('Failed to load','error');});
+}
+function exportCharts(){
+    const canvas=document.getElementById('tokenChart');
+    const link=document.createElement('a');
+    link.download='chart.png';
+    link.href=canvas.toDataURL();
+    link.click();
+}
+loadStats();
+</script>
+</body>
+</html>

--- a/public/stats_data.php
+++ b/public/stats_data.php
@@ -1,0 +1,9 @@
+<?php
+require __DIR__.'/lib.php';
+$pdo=get_pdo();
+$rows=$pdo->query("SELECT DATE(created_at) d, SUM(tokens) t FROM api_logs GROUP BY d ORDER BY d")->fetchAll(PDO::FETCH_ASSOC);
+$labels=[];$data=[];
+foreach($rows as $r){$labels[]=$r['d'];$data[]=(int)$r['t'];}
+$success=$pdo->query("SELECT AVG(success)*100 AS rate FROM api_logs")->fetchColumn();
+header('Content-Type: application/json; charset=utf-8');
+echo json_encode(['tokens'=>['labels'=>$labels,'data'=>$data],'success'=>round($success,2)]);

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,16 @@
+:root{--bg:#fff;--text:#000;--accent:#333;}
+[data-theme="dark"]{--bg:#121212;--text:#eee;--accent:#888;}
+body{margin:0;font-family:Arial,sans-serif;background:var(--bg);color:var(--text);transition:background .3s,color .3s;}
+.nav{display:flex;background:var(--accent);color:#fff;padding:10px;align-items:center;}
+.nav a{margin-right:10px;color:#fff;text-decoration:none;}
+.nav-toggle{margin-left:auto;background:none;border:none;color:#fff;font-size:18px;cursor:pointer;}
+.nav-links{display:flex;}
+@media(max-width:600px){.nav{flex-wrap:wrap;}.nav-links{width:100%;flex-direction:column;display:none;}.nav-links.show{display:flex;}}
+.content{padding:20px;}
+.loading-overlay{display:none;position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,.5);align-items:center;justify-content:center;z-index:1000;color:#fff;font-size:20px;}
+.toast-container{position:fixed;right:10px;bottom:10px;z-index:2000;}
+.toast{margin-top:5px;padding:10px 20px;background:#333;color:#fff;border-radius:4px;opacity:.9;animation:fadein .3s,fadeout .3s 2.7s;}
+@keyframes fadein{from{opacity:0;}to{opacity:.9;}}
+@keyframes fadeout{from{opacity:.9;}to{opacity:0;}}
+.progress-bar{width:80%;height:10px;background:#ccc;border-radius:5px;overflow:hidden;margin:10px 0;}
+.progress-bar div{height:100%;width:0;background:#09f;transition:width .3s;}

--- a/public/test.php
+++ b/public/test.php
@@ -3,10 +3,28 @@ session_start();
 if (!isset($_SESSION['user_id'])) { header('Location: index.php'); exit; }
 ?>
 <!DOCTYPE html>
-<html><head><meta charset="utf-8"><title>Function Test</title>
-<style>body{font-family:Arial;padding:20px;}textarea{width:100%;height:100px;}</style>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Function Test</title>
+<link rel="stylesheet" href="style.css">
+<script src="script.js" defer></script>
+<style>textarea{width:100%;height:100px;}</style>
 </head>
 <body>
+<div class="nav">
+    <div class="nav-links">
+        <a href="dashboard.php">Dashboard</a>
+        <a href="api_keys.php">API Keys</a>
+        <a href="one_keys.php">One Keys</a>
+        <a href="test.php">Function Test</a>
+        <a href="stats.php">Stats</a>
+        <a href="logout.php">Logout</a>
+    </div>
+    <button class="nav-toggle" onclick="toggleNav()">☰</button>
+    <button id="theme-toggle" class="nav-toggle" onclick="toggleTheme()">🌗</button>
+</div>
+<div class="content">
 <h2>Function Test</h2>
 <textarea id="log" readonly></textarea><br>
 <input id="msg" placeholder="Message"><button onclick="send()">Send</button>
@@ -18,5 +36,8 @@ function send(){
     .then(r=>r.text()).then(t=>{log.value+=t+'\n';});
 }
 </script>
-<p><a href="dashboard.php">Back</a></p>
-</body></html>
+</div>
+<div id="loading" class="loading-overlay"><div>Loading...</div></div>
+<div class="toast-container"></div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add global CSS and JS for theme toggle, loading overlay, toast notifications, and responsive navigation
- refactor existing PHP pages to use the new navigation and client validation
- add statistics page with Chart.js graphs for token usage and API success rate
- log API calls to new table created during setup

## Testing
- `php -l` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68418bb525a4832388f605bc56381509