### PR TITLE
Add log file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /[Ll]ogs/
 /[Uu]ser[Ss]ettings/
 *.log
+log.txt
 
 # By default unity supports Blender asset imports, *.blend1 blender files do not need to be commited to version control.
 *.blend1

--- a/public/api_keys.php
+++ b/public/api_keys.php
@@ -1,5 +1,6 @@
 <?php
 session_start();
+require __DIR__.'/lib.php';
 if (!isset($_SESSION['user_id'])) { header('Location: index.php'); exit; }
 $config = require __DIR__ . '/../config.php';
 $pdo = new PDO("mysql:host={$config['db_host']};dbname={$config['db_name']};charset=utf8mb4", $config['db_user'], $config['db_pass']);
@@ -7,10 +8,12 @@ $pdo = new PDO("mysql:host={$config['db_host']};dbname={$config['db_name']};char
 if (isset($_POST['add'])) {
     $stmt = $pdo->prepare('INSERT INTO api_keys(api_key,remark,active,flag) VALUES(?,?,?,?)');
     $stmt->execute([$_POST['api_key'], $_POST['remark'], isset($_POST['active'])?1:0, $_POST['flag']]);
+    log_action('Add API key');
 }
 if (isset($_GET['delete'])) {
     $stmt = $pdo->prepare('DELETE FROM api_keys WHERE id=?');
     $stmt->execute([$_GET['delete']]);
+    log_action('Delete API key '.$_GET['delete']);
 }
 $keys = $pdo->query('SELECT * FROM api_keys')->fetchAll(PDO::FETCH_ASSOC);
 ?>

--- a/public/index.php
+++ b/public/index.php
@@ -1,6 +1,8 @@
 <?php
 session_start();
 
+require __DIR__.'/lib.php';
+
 $configFile = __DIR__ . '/../config.php';
 if (!file_exists($configFile)) {
     header('Location: setup.php');
@@ -24,10 +26,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $user = $stmt->fetch(PDO::FETCH_ASSOC);
     if ($user) {
         $_SESSION['user_id'] = $user['id'];
+        log_action("Login success for {$username}");
         header('Location: dashboard.php');
         exit;
     } else {
         $error = 'Invalid credentials';
+        log_action("Login failed for {$username}");
     }
 }
 ?>

--- a/public/lib.php
+++ b/public/lib.php
@@ -50,9 +50,16 @@ function rate_limit_check($one){
     $stmt->execute([$allowance, $now, $one['id']]);
 }
 
+function log_action($message){
+    $file = __DIR__ . '/../log.txt';
+    $time = date('Y-m-d H:i:s');
+    file_put_contents($file, "[$time] $message\n", FILE_APPEND | LOCK_EX);
+}
+
 function log_api_call($success,$tokens=0){
     $pdo=get_pdo();
     $stmt=$pdo->prepare('INSERT INTO api_logs(success,tokens) VALUES(?,?)');
     $stmt->execute([$success?1:0,$tokens]);
+    log_action('API call '.($success?'success':'fail')." tokens=$tokens");
 }
 ?>

--- a/public/logout.php
+++ b/public/logout.php
@@ -1,4 +1,7 @@
 <?php
 session_start();
+require __DIR__.'/lib.php';
+$uid = isset($_SESSION['user_id']) ? $_SESSION['user_id'] : 'unknown';
+log_action("Logout user {$uid}");
 session_destroy();
 header('Location: index.php');

--- a/public/one_keys.php
+++ b/public/one_keys.php
@@ -1,5 +1,6 @@
 <?php
 session_start();
+require __DIR__.'/lib.php';
 if (!isset($_SESSION['user_id'])) { header('Location: index.php'); exit; }
 $config = require __DIR__ . '/../config.php';
 $pdo = new PDO("mysql:host={$config['db_host']};dbname={$config['db_name']};charset=utf8mb4", $config['db_user'], $config['db_pass']);
@@ -10,10 +11,12 @@ if (isset($_POST['add'])) {
     $key = random_key();
     $stmt = $pdo->prepare('INSERT INTO one_keys(one_key,remark) VALUES(?,?)');
     $stmt->execute([$key,$_POST['remark']]);
+    log_action('Generate One_Key');
 }
 if (isset($_GET['delete'])) {
     $stmt = $pdo->prepare('DELETE FROM one_keys WHERE id=?');
     $stmt->execute([$_GET['delete']]);
+    log_action('Delete One_Key '.$_GET['delete']);
 }
 $keys = $pdo->query('SELECT * FROM one_keys')->fetchAll(PDO::FETCH_ASSOC);
 ?>

--- a/public/setup.php
+++ b/public/setup.php
@@ -1,5 +1,6 @@
 <?php
 session_start();
+require __DIR__.'/lib.php';
 $configFile = __DIR__ . '/../config.php';
 if (file_exists($configFile)) {
     header('Location: index.php');
@@ -26,10 +27,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $stmt->execute([$admin,$admin_pass]);
         $config = ['db_host'=>$db_host,'db_user'=>$db_user,'db_pass'=>$db_pass,'db_name'=>$db_name];
         file_put_contents($configFile, "<?php\nreturn " . var_export($config,true) . ";\n");
+        log_action('Setup completed');
         header('Location: index.php');
         exit;
     } catch (Exception $e) {
         $error = $e->getMessage();
+        log_action('Setup error: '.$error);
     }
 }
 ?>


### PR DESCRIPTION
## Summary
- log API calls to log.txt
- log login, logout and setup events
- log admin actions for API keys and One_Key generation
- ignore log.txt in git

## Testing
- `php -l` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68418eecf7a0832386a68dbfec9a141d