### PR TITLE
Fix open_basedir path

### DIFF
--- a/public/api_keys.php
+++ b/public/api_keys.php
@@ -2,7 +2,7 @@
 session_start();
 require __DIR__.'/lib.php';
 if (!isset($_SESSION['user_id'])) { header('Location: index.php'); exit; }
-$config = require __DIR__ . '/../config.php';
+$config = require __DIR__ . '/config.php';
 $pdo = new PDO("mysql:host={$config['db_host']};dbname={$config['db_name']};charset=utf8mb4", $config['db_user'], $config['db_pass']);
 
 if (isset($_POST['add'])) {

--- a/public/dashboard.php
+++ b/public/dashboard.php
@@ -1,6 +1,6 @@
 <?php
 session_start();
-$config = require __DIR__ . '/../config.php';
+$config = require __DIR__ . '/config.php';
 if (!isset($_SESSION['user_id'])) {
     header('Location: index.php');
     exit;

--- a/public/index.php
+++ b/public/index.php
@@ -3,7 +3,7 @@ session_start();
 
 require __DIR__.'/lib.php';
 
-$configFile = __DIR__ . '/../config.php';
+$configFile = __DIR__ . '/config.php';
 if (!file_exists($configFile)) {
     header('Location: setup.php');
     exit;

--- a/public/lib.php
+++ b/public/lib.php
@@ -2,7 +2,7 @@
 function get_pdo(){
     static $pdo=null;
     if($pdo===null){
-        $config = require __DIR__ . '/../config.php';
+        $config = require __DIR__ . '/config.php';
         $pdo = new PDO("mysql:host={$config['db_host']};dbname={$config['db_name']};charset=utf8mb4", $config['db_user'], $config['db_pass']);
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
     }
@@ -51,7 +51,7 @@ function rate_limit_check($one){
 }
 
 function log_action($message){
-    $file = __DIR__ . '/../log.txt';
+    $file = __DIR__ . '/log.txt';
     $time = date('Y-m-d H:i:s');
     file_put_contents($file, "[$time] $message\n", FILE_APPEND | LOCK_EX);
 }

--- a/public/one_keys.php
+++ b/public/one_keys.php
@@ -2,7 +2,7 @@
 session_start();
 require __DIR__.'/lib.php';
 if (!isset($_SESSION['user_id'])) { header('Location: index.php'); exit; }
-$config = require __DIR__ . '/../config.php';
+$config = require __DIR__ . '/config.php';
 $pdo = new PDO("mysql:host={$config['db_host']};dbname={$config['db_name']};charset=utf8mb4", $config['db_user'], $config['db_pass']);
 
 function random_key($len=24){ return substr(str_shuffle(str_repeat('0123456789abcdef', $len)),0,$len); }

--- a/public/setup.php
+++ b/public/setup.php
@@ -1,7 +1,7 @@
 <?php
 session_start();
 require __DIR__.'/lib.php';
-$configFile = __DIR__ . '/../config.php';
+$configFile = __DIR__ . '/config.php';
 if (file_exists($configFile)) {
     header('Location: index.php');
     exit;


### PR DESCRIPTION
## Summary
- avoid using parent directory for config or log file
- keep config.php and log.txt inside `public`

## Testing
- `php -l public/index.php`
- `for f in public/*.php; do php -l $f; done`

------
https://chatgpt.com/codex/tasks/task_e_684190914ae48323ab14eb87563d8718