### PR TITLE
Improve setup resilience and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Provides a JSON API with basic rate limiting and weighted key rotation.
 1. Deploy files under a PHP-enabled web server.
 2. Access `/public/setup.php` on first run to configure database and admin account.
 3. After setup, login via `/public/index.php`.
+4. Log messages are written to `public/log.txt` and the file will be created automatically if permissions allow.
 
 ## Features
 

--- a/public/lib.php
+++ b/public/lib.php
@@ -53,7 +53,14 @@ function rate_limit_check($one){
 function log_action($message){
     $file = __DIR__ . '/log.txt';
     $time = date('Y-m-d H:i:s');
-    file_put_contents($file, "[$time] $message\n", FILE_APPEND | LOCK_EX);
+    $dir = dirname($file);
+    if(is_dir($dir) && is_writable($dir)){
+        if(@file_put_contents($file, "[$time] $message\n", FILE_APPEND | LOCK_EX) === false){
+            error_log("Failed to write log: [$time] $message");
+        }
+    }else{
+        error_log("Log directory not writable: $dir");
+    }
 }
 
 function log_api_call($success,$tokens=0){

--- a/public/setup.php
+++ b/public/setup.php
@@ -27,10 +27,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec("CREATE DATABASE IF NOT EXISTS `$db_name` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
         $pdo->exec("USE `$db_name`");
-        $pdo->exec("CREATE TABLE users(id INT AUTO_INCREMENT PRIMARY KEY, username VARCHAR(50) UNIQUE, password VARCHAR(32))");
-        $pdo->exec("CREATE TABLE api_keys(id INT AUTO_INCREMENT PRIMARY KEY, api_key VARCHAR(255), remark VARCHAR(255), active TINYINT(1) DEFAULT 1, flag INT, weight INT DEFAULT 1)");
-        $pdo->exec("CREATE TABLE one_keys(id INT AUTO_INCREMENT PRIMARY KEY, one_key CHAR(24) UNIQUE, remark VARCHAR(255), tokens_used INT DEFAULT 0, qps_limit INT DEFAULT 60, allowance FLOAT DEFAULT 60, last_check INT DEFAULT 0)");
-        $pdo->exec("CREATE TABLE api_logs(id INT AUTO_INCREMENT PRIMARY KEY, success TINYINT(1), tokens INT DEFAULT 0, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)");
+        $pdo->exec("CREATE TABLE IF NOT EXISTS users(id INT AUTO_INCREMENT PRIMARY KEY, username VARCHAR(50) UNIQUE, password VARCHAR(32))");
+        $pdo->exec("CREATE TABLE IF NOT EXISTS api_keys(id INT AUTO_INCREMENT PRIMARY KEY, api_key VARCHAR(255), remark VARCHAR(255), active TINYINT(1) DEFAULT 1, flag INT, weight INT DEFAULT 1)");
+        $pdo->exec("CREATE TABLE IF NOT EXISTS one_keys(id INT AUTO_INCREMENT PRIMARY KEY, one_key CHAR(24) UNIQUE, remark VARCHAR(255), tokens_used INT DEFAULT 0, qps_limit INT DEFAULT 60, allowance FLOAT DEFAULT 60, last_check INT DEFAULT 0)");
+        $pdo->exec("CREATE TABLE IF NOT EXISTS api_logs(id INT AUTO_INCREMENT PRIMARY KEY, success TINYINT(1), tokens INT DEFAULT 0, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)");
         $stmt = $pdo->prepare('INSERT INTO users(username,password) VALUES(?,?)');
         $stmt->execute([$admin,$admin_pass]);
         $config = ['db_host'=>$db_host,'db_user'=>$db_user,'db_pass'=>$db_pass,'db_name'=>$db_name];


### PR DESCRIPTION
## Summary
- handle missing write permissions when logging
- make setup table creation idempotent
- document log.txt behavior in README

## Testing
- `php -l public/lib.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68419791675c83239ebea0fb8659af9a